### PR TITLE
Fix syntax error in initscript

### DIFF
--- a/debian_package/sbin/folder2ram
+++ b/debian_package/sbin/folder2ram
@@ -155,7 +155,7 @@ if [ "$Timeout" = '' ] ; then
        Timeout=2m
 fi
 
-function timeout_monitor() {
+timeout_monitor() {
    sleep "$Timeout"
    kill "$1"
 }


### PR DESCRIPTION
Fix for `Syntax error: "(" unexpected` in initscript.